### PR TITLE
add default btn components about atoms components

### DIFF
--- a/frontend/components/atoms/DefaultBtn.tsx
+++ b/frontend/components/atoms/DefaultBtn.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+// next
+import Link from "next/link";
+
+// scss
+import styles from "./styles/DefaultBtn.module.scss";
+
+// props
+export type DefaultBtnProps = {
+  link: string;
+  text: string;
+};
+
+const DefaultBtn = ({ link, text }: DefaultBtnProps) => {
+  return (
+    <Link className={styles.btn} href={link}>
+      {text}
+    </Link>
+  );
+};
+
+export default DefaultBtn;

--- a/frontend/components/atoms/NewsItem.tsx
+++ b/frontend/components/atoms/NewsItem.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+// scss
+import styles from "./styles/NewsItem.module.scss";
+import Link from "next/link";
+
+// props
+export type NewsItemProps = {
+  id: number;
+  link: string;
+  date: string;
+  genre: string;
+  text: string;
+};
+
+const NewsItem = ({ id, link, date, genre, text }: NewsItemProps) => {
+  return <Link key={id} className={styles.newsBox} href={link}></Link>;
+};
+
+export default NewsItem;

--- a/frontend/components/atoms/styles/DefaultBtn.module.scss
+++ b/frontend/components/atoms/styles/DefaultBtn.module.scss
@@ -1,0 +1,29 @@
+.btn {
+  position: relative;
+  width: 180px;
+  height: 60px;
+  color: #ffffff;
+  text-decoration: none;
+  text-transform: uppercase;
+  text-align: center;
+  line-height: 60px;
+  letter-spacing: 2px;
+  margin: 20px;
+  transition: 0.5s;
+  padding: 10px 20px;
+  &:hover {
+    background: #05ff0d url("https://i.postimg.cc/5QwqVNjf/pixel.png");
+    transition-delay: 0.8s;
+    background-size: 180px;
+    animation: Animate 0.8s steps(8) forwards;
+  }
+}
+
+@keyframes Animate {
+  0% {
+    background-position-y: 0;
+  }
+  100% {
+    background-position-y: -480px;
+  }
+}

--- a/frontend/components/organisms/News.tsx
+++ b/frontend/components/organisms/News.tsx
@@ -2,11 +2,13 @@ import React from "react";
 
 // scss
 import styles from "./styles/News.module.scss";
+// import DefaultBtn from "../atoms/DefaultBtn";
 
 const News = () => {
   return (
     <div className={styles.news}>
-      <h1>news</h1>
+      <div className={styles.titleBox}></div>
+      <div className={styles.itemBox}></div>
     </div>
   );
 };

--- a/frontend/components/organisms/styles/Top.module.scss
+++ b/frontend/components/organisms/styles/Top.module.scss
@@ -17,7 +17,7 @@
     height: 100%;
     .center {
       padding-left: 30px;
-      margin-top: 450px;
+      margin-top: 500px;
       font-family: "IBM Plex Mono", monospace;
       font-weight: 400;
       font-size: 22px;
@@ -43,11 +43,11 @@
       .center {
         position: absolute;
         width: 400px;
-        top: 65%;
+        top: 70%;
         margin-top: 0px;
 
         padding-left: 30px;
-        font-size: 16px;
+        font-size: 14px;
         line-height: 24px;
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `DefaultBtn` component for rendering buttons with links.
  - Added a `NewsItem` component to display individual news items with relevant details.

- **Style Updates**
  - Implemented new styling for the `DefaultBtn` including hover effects and animations.
  - Adjusted the layout of the `News` component, replacing a headline with organized title and item sections.
  - Updated CSS properties in `Top.module.scss` to enhance alignment and text readability.

- **Refactor**
  - Modified structure and styling in `News` component for better visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->